### PR TITLE
Removed the sdout identifier to clean up output.

### DIFF
--- a/lib/lita/handlers/cmd.rb
+++ b/lib/lita/handlers/cmd.rb
@@ -42,7 +42,7 @@ module Lita
         out = String.new
         err = String.new
         Open3.popen3("#{config.scripts_dir}/#{script}", *opts) do |i, o, e, wait_thread|
-          o.each { |line| out << "[stdout] #{line}" }
+          o.each { |line| out << "#{line}" }
           e.each { |line| err << "[stderr] #{line}" }
         end
 


### PR DESCRIPTION
For my use, I only need to highlight when something gets written to stderr.  Removing the stdout identifier makes the output more copy & paste friendly.
