### PR TITLE
Add configuration for output format and prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,19 @@ gem "lita-cmd"
 
 ```ruby
 Lita.configure do |config|
-  # Lita CMD stuff
+  # Lita CMD - required parameters
+  
   config.handlers.cmd.scripts_dir = "/path/to/dir/you/expose"
+
+  # Lita CMD - optional parameters
+
+  # Set the output format. Default: "```\n%s\n```"
+  config.handlers.cmd.output_format = "/code %s"
+
+  # Set the prefix of stdout and stderr. Default: "[stdout] " and "[stderr] "
+  config.handlers.cmd.stdout_prefix = ""
+  config.handlers.cmd.stderr_prefix = "ERROR: "
+
 end
 ```
 

--- a/lib/lita/handlers/cmd.rb
+++ b/lib/lita/handlers/cmd.rb
@@ -4,7 +4,10 @@ module Lita
   module Handlers
     class Cmd < Handler
 
-      config :scripts_dir
+      config :scripts_dir, required: true
+      config :output_format, default: "```\n%s\n```"
+      config :stdout_prefix, default: "[stdout] "
+      config :stderr_prefix, default: "[stderr] "
 
       ### CMD-HELP ##############################################
 
@@ -42,8 +45,8 @@ module Lita
         out = String.new
         err = String.new
         Open3.popen3("#{config.scripts_dir}/#{script}", *opts) do |i, o, e, wait_thread|
-          o.each { |line| out << "[stdout] #{line}" }
-          e.each { |line| err << "[stderr] #{line}" }
+          o.each { |line| out << "#{config.stdout_prefix}#{line}" }
+          e.each { |line| err << "#{config.stderr_prefix}#{line}" }
         end
 
         if err != String.new
@@ -66,8 +69,9 @@ module Lita
       ### HELPERS ############################################
 
       private
+
       def code_blockify(text)
-        "```\n#{text}\n```"
+        config.output_format % text
       end
 
       def get_script_list(resp, config)


### PR DESCRIPTION
This PR comes to address the need (issue #1) for removing backticks and `[stdout]/[stderr]` markers from the output in some cases, like when using with HipChat.

It adds these three optional configuration parameters:

``` ruby
  config.handlers.cmd.output_format = "/code %s"   # example for nice HipChat output
  config.handlers.cmd.stdout_prefix = ""
  config.handlers.cmd.stderr_prefix = "ERROR: "
```

I have left the defaults as they were, and added documentation in the `README`.
