### PR TITLE
fix for slack's empty robot.name

### DIFF
--- a/lib/lita/handlers/cmd.rb
+++ b/lib/lita/handlers/cmd.rb
@@ -22,12 +22,12 @@ module Lita
         opts = resp.matches[0][1].split(" ")
 
         # the script will be the robot name if command_prefix is empty
-        return if script =~ /@?#{robot.name}/i
+        return if robot_name and script =~ /^@?#{robot_name}$/i
 
         return show_help(resp) if script == 'list'
 
         unless user_is_authorized(script, resp, config)
-          resp.reply_privately "Unauthorized to run '#{script}'!"
+          resp.reply_privately "Unauthorized to run '#{script}'!" unless config.command_prefix.empty? 
           return
         end
 
@@ -96,6 +96,12 @@ module Lita
       def user_is_authorized(script, resp, config)
         list = get_script_list(resp, config)
         list.include? script
+      end
+
+      def robot_name
+        return robot.name unless robot.name.empty?
+        return robot.mention_name unless robot.mention_name.empty?
+        return false
       end
     end
 


### PR DESCRIPTION
This comes to address the issue in #11 

The problem seems to be that `robot.name` returned empty from slack. Instead, the name was in `robot.mention_name`

In addition, made some adjustments to make this part of the code a little less fragile hopefully:
1. Instead of testing `robot.name`, we will now test against our `robot_name` method, which tries to find the name in one of the two variables
2. The previously offending line `return if script =~ /@?#{robot.name}/i` now verifies it actually has a robot_name to work against.
3. In the event that the user has chosen to configure `command_prefix` to be empty, we will no longer complain about unauthorized access, since there is no way (I could think of) to distinguish between a command like `help` that was already intercepted higher in the stack, and actual unauthorized commands. 

I believe this is a good solution, tested in slack and hipchat, both private chat with the bot and public, and both with a command prefix and without. Would love a second eye on this though.
