### PR TITLE
added support for LITA_CRED

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gem "lita-cmd"
 |`stderr_prefix` |Prefix for text returned to STDERR    |`String`|          |
 |`output_format` |Format string used to encapsulate code|`String`|          |
 |`command_prefix`|Command to use for executing scripts  |`String`|          |
-
+|`ignore_script` |regexp of non-script files to ignore  |`Regexp`|          |
 
 ### Example
 
@@ -40,6 +40,9 @@ Lita.configure do |config|
 
   # Set the prefix for running scripts.
   config.handlers.cmd.command_prefix = "run "
+
+  # Set the characters that, if present, will cause a file to not be flagged as a script
+  config.handlers.cmd.ignore_script = Regexp.union(/~/, /#/)
 
 end
 ```

--- a/lib/lita/handlers/cmd.rb
+++ b/lib/lita/handlers/cmd.rb
@@ -37,6 +37,9 @@ module Lita
 
         script_path = "#{config.scripts_dir}/#{script}"
         env_vars    = { 'LITA_USER' => resp.user.name }
+        script_group = script.split('/')[0]
+        cred = resp.user.metadata["cred-#{script_group}"]
+        env_vars['LITA_CRED'] = cred unless cred.nil?
 
         Open3.popen3(env_vars, script_path, *opts) do |i, o, e, wait_thread|
           o.each { |line| out << "#{config.stdout_prefix}#{line}" }


### PR DESCRIPTION
Just sharing back - I needed to share credentials for some of my scripts. This will take credentials stored in redis and share them with the script in a LITA_CRED environment variable. I generally will set this to the username:password, base 64 encoded, but it's up to the specific script to define a format it would want for a credential.

I generally add the credentials to the lita redis DB out-of-band for security considerations. An alternative might be a script that takes credentials via some sort of DM. 
