### PR TITLE
Ignore Scripts Based on Filename Patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ gem "lita-cmd"
 
 ## Configuration
 
-| Config Option  | Description                          | Type   | Notes    |
-|----------------|--------------------------------------|--------|----------|
-|`scripts_dir`   |Full path to location of scripts      |`String`|*required*|
-|`stdout_prefix` |Prefix for text returned to STDOUT    |`String`|          |
-|`stderr_prefix` |Prefix for text returned to STDERR    |`String`|          |
-|`output_format` |Format string used to encapsulate code|`String`|          |
-|`command_prefix`|Command to use for executing scripts  |`String`|          |
+| Config Option  | Description                            | Type   | Notes    |
+|----------------|----------------------------------------|--------|----------|
+|`scripts_dir`   |Full path to location of scripts        |`String`|*required*|
+|`stdout_prefix` |Prefix for text returned to STDOUT      |`String`|          |
+|`stderr_prefix` |Prefix for text returned to STDERR      |`String`|          |
+|`output_format` |Format string used to encapsulate code  |`String`|          |
+|`command_prefix`|Command to use for executing scripts    |`String`|          |
+|`ignore_pattern`|Patterns to ignore when getting commands|`Regexp`|          |
 
 ### Example
 

--- a/lib/lita/handlers/cmd.rb
+++ b/lib/lita/handlers/cmd.rb
@@ -11,6 +11,7 @@ module Lita
       config :stdout_prefix, default: ""
       config :stderr_prefix, default: "ERROR: "
       config :command_prefix, default: "cmd "
+      config :ignore_pattern, default: Regexp.union(/~/, /#/)
 
       def create_routes(payload)
         self.class.route(/^\s*#{config.command_prefix}(\S+)\s*(.*)$/, :run_action, command: true, help: {
@@ -109,12 +110,18 @@ module Lita
           list.concat sublist.map { |x| "#{group}/#{x}" } if sublist
         end
 
-        list
+        filter_scrips(list, config)
       end
 
       def user_is_authorized(script, resp, config)
         list = get_script_list(resp, config)
         list.include? script
+      end
+
+      def filter_scrips(list, config)
+        list.delete_if do |item|
+          config.ignore_pattern.match(item)
+        end
       end
 
       def robot_name


### PR DESCRIPTION
This lets the user configure Regex that will ignore scripts. Useful for ignoring tmp files and other artifacts that wind up in the script.

Could also be used for scripts that reference files that should not be called - e.g. the Dotenv gem.
